### PR TITLE
CWE-22 Fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -239,7 +239,26 @@ func systemStatsHandler(w http.ResponseWriter, r *http.Request) {
 func deleteImageHandler(w http.ResponseWriter, r *http.Request) {
     r.ParseForm()
     img := r.FormValue("image")
-    os.Remove(filepath.Join("uploads", img))
+
+    // Clean the provided path
+    cleanImage := filepath.Clean(img)
+
+    // Define and normalize the base uploads directory
+    baseDir := filepath.Clean("uploads")
+    fullPath := filepath.Join(baseDir, cleanImage)
+
+    // Ensure the path stays within the uploads directory
+    if !strings.HasPrefix(fullPath, baseDir+string(os.PathSeparator)) {
+        http.Error(w, "Invalid file path", http.StatusBadRequest)
+        return
+    }
+
+    // Attempt to delete the file
+    if err := os.Remove(fullPath); err != nil {
+        http.Error(w, "Failed to delete file", http.StatusInternalServerError)
+        return
+    }
+
     w.Write([]byte("deleted"))
 }
 


### PR DESCRIPTION
fix: prevent path traversal in /api/deleteImage by validating filename input

- Sanitizes user-supplied "image" parameter using filepath.Clean
- Ensures deletion path remains within the "uploads/" directory
- Blocks malicious input like "../main.go" or encoded variants ("%2F")
- Prevents unauthorized file deletion outside the uploads scope

CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')